### PR TITLE
Added Thumbs.db:encryptable to Windows.gitignore

### DIFF
--- a/Global/Windows.gitignore
+++ b/Global/Windows.gitignore
@@ -1,5 +1,6 @@
 # Windows image file caches
 Thumbs.db
+Thumbs.db:encryptable
 ehthumbs.db
 
 # Folder config file


### PR DESCRIPTION
**Reasons for making this change:**

Windows invented new variation for Thumbs.db file.

